### PR TITLE
Add options to change order of custom commands

### DIFF
--- a/src/ui/settingsTab.ts
+++ b/src/ui/settingsTab.ts
@@ -53,7 +53,9 @@ export default class CustomSidebarSettingsTab extends PluginSettingTab {
                             this.plugin.settings.sidebarCommands.remove(c);
                             await this.plugin.saveSettings();
                             this.display();
-                            new Notice("You will need to restart Obsidian for the command to disappear.")
+                            const ribbonButton = Array.from(this.leftRibbonPanel.children)
+                                .find((btn) => c.name === btn.getAttribute('aria-label'))
+                            this.leftRibbonPanel.removeChild(ribbonButton);
                         })
                 })
                 .addExtraButton(bt => {
@@ -99,7 +101,9 @@ export default class CustomSidebarSettingsTab extends PluginSettingTab {
             });
 
     }
+
+    private get leftRibbonPanel(): HTMLElement {
+        // @ts-ignore `ribbonActionsEl` is not defined in api
+        return this.app.workspace.leftRibbon.ribbonActionsEl as HTMLElement;
+    }
 }
-
-
-

--- a/src/ui/settingsTab.ts
+++ b/src/ui/settingsTab.ts
@@ -41,11 +41,27 @@ export default class CustomSidebarSettingsTab extends PluginSettingTab {
                     });
             });
 
-        this.plugin.settings.sidebarCommands.forEach(c => {
+        this.plugin.settings.sidebarCommands.forEach((c, index) => {
             const iconDiv = createDiv({ cls: "CS-settings-icon" });
             setIcon(iconDiv, c.icon, 20);
             const setting = new Setting(containerEl)
-                .setName(c.name)
+                .setName(c.name);
+
+            if (index > 0) {
+                setting.addExtraButton(bt => {
+                    bt.setIcon("up-arrow-with-tail")
+                        .setTooltip("Move up")
+                        .onClick(async () => await this.moveCommand(c, 'up'));
+                })
+            }
+            if (index < this.plugin.settings.sidebarCommands.length - 1) {
+                setting.addExtraButton(bt => {
+                    bt.setIcon("down-arrow-with-tail")
+                        .setTooltip("Move down")
+                        .onClick(async () => await this.moveCommand(c, 'down'));
+                })
+            }
+            setting
                 .addExtraButton(bt => {
                     bt.setIcon("trash")
                         .setTooltip("Remove Command")
@@ -105,5 +121,27 @@ export default class CustomSidebarSettingsTab extends PluginSettingTab {
     private get leftRibbonPanel(): HTMLElement {
         // @ts-ignore `ribbonActionsEl` is not defined in api
         return this.app.workspace.leftRibbon.ribbonActionsEl as HTMLElement;
+    }
+
+    private async moveCommand(command: Command, direction: 'up' | 'down') {
+        // Move command in settings
+        const commands = this.plugin.settings.sidebarCommands;
+        const index = commands.indexOf(command);
+        if (direction === 'up') {
+            commands.splice(index - 1, 0, commands.splice(index, 1)[0]);
+        } else {
+            commands.splice(index + 1, 0, commands.splice(index, 1)[0]);
+        }
+        await this.plugin.saveSettings();
+        this.display();
+
+        // Move command button in left ribbon
+        const ribbonButton = Array.from(this.leftRibbonPanel.children)
+            .find((btn) => command.name === btn.getAttribute('aria-label'));
+        if (direction === 'up') {
+            ribbonButton.previousSibling.before(ribbonButton);
+        } else {
+            ribbonButton.nextSibling.after(ribbonButton);
+        }
     }
 }


### PR DESCRIPTION
This PR adds one improvement and implements a feature request #4.

1. Command buttons are now removed from ribbon immediately, no restart necessary 
2. I've added up/down arrow buttons in command settings to reorder commands (closes #4)
![image](https://user-images.githubusercontent.com/1130547/151587100-61dfdb70-705b-44b9-b086-03fe3b2ce80d.png)
